### PR TITLE
fix: esphome deprecations (#5)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/setup-python@v4
         id: python
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Cache virtualenv
         uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Smart PHC controller with PHC-Modules. A close up of the board containing the ES
 
 # Requirements
 
-This project has been developed and tested on an ESP32. A ESP8266 is probably going to work just fine. For best results use an ESP32 in combination with the Arduino Framework. The use of the and ESP8266 or the IDF framework will likely result in incorrectly timed messages on the bus.
+This project has been developed and tested on an ESP32. A ESP8266 is probably going to work just fine. For best results use an ESP32 in combination with the IDF Framework. As of ESPHome 2025.10, support for the Arduino Framework has been dropped due to underlying changes in ESPHome. The recommended installation method (and default in ESPHome as of 2026.1) is using the IDF Framework.
 
 The PHC-Bus is RS-485 based. In order communicate on the bus a RS-485 TTL Adapter is required. Currently only a Chip with automatic flow control has been tested.
 Connect the A/B wires to the PHC-bus. This can easily be done using the screw-terminal on the power-supply ([see](power_supply.jpg)).

--- a/components/AMD/light.py
+++ b/components/AMD/light.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import light, output, switch
+from esphome.components import light
+from esphome.components.light import LightType
 from esphome.const import CONF_OUTPUT_ID
 
 from ..PHCController import CONTROLLER_ID, PHCController
@@ -13,14 +14,18 @@ CHANNEL = "channel"
 amd_light_ns = cg.esphome_ns.namespace("AMD_binary")
 AMDLight = amd_light_ns.class_("AMD_light", cg.Component, light.LightOutput)
 
-CONFIG_SCHEMA = light.BINARY_LIGHT_SCHEMA.extend(
-    {
-        cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(AMDLight),
-        cv.Required(CONTROLLER_ID): cv.use_id(PHCController),
-        cv.Required(ADDRESS): cv.int_range(min=0, max=31),
-        cv.Required(CHANNEL): cv.int_range(min=0, max=7),
-    }
-).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = (
+    light.light_schema(AMDLight, type_=LightType.BINARY)
+    .extend(
+        {
+            cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(AMDLight),
+            cv.Required(CONTROLLER_ID): cv.use_id(PHCController),
+            cv.Required(ADDRESS): cv.int_range(min=0, max=31),
+            cv.Required(CHANNEL): cv.int_range(min=0, max=7),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 def to_code(config):

--- a/components/AMD/switch.py
+++ b/components/AMD/switch.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import light, switch
+from esphome.components import switch
 from esphome.const import CONF_DEVICE_CLASS, CONF_ID, DEVICE_CLASS_OUTLET
 
 from ..PHCController import CONTROLLER_ID, PHCController
@@ -13,15 +13,19 @@ CHANNEL = "channel"
 AMD_ns = cg.esphome_ns.namespace("AMD_binary")
 AMD = AMD_ns.class_("AMD_switch", switch.Switch, cg.Component)
 
-CONFIG_SCHEMA = switch.SWITCH_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(AMD),
-        cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_OUTLET): cv.string,
-        cv.Required(CONTROLLER_ID): cv.use_id(PHCController),
-        cv.Required(ADDRESS): cv.int_range(min=0, max=31),
-        cv.Required(CHANNEL): cv.int_range(min=0, max=7),
-    }
-).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = (
+    switch.switch_schema(AMD)
+    .extend(
+        {
+            cv.GenerateID(): cv.declare_id(AMD),
+            cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_OUTLET): cv.string,
+            cv.Required(CONTROLLER_ID): cv.use_id(PHCController),
+            cv.Required(ADDRESS): cv.int_range(min=0, max=31),
+            cv.Required(CHANNEL): cv.int_range(min=0, max=7),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 def to_code(config):

--- a/components/EMD/binary_sensor.py
+++ b/components/EMD/binary_sensor.py
@@ -14,14 +14,18 @@ CHANNEL = "channel"
 EMD_ns = cg.esphome_ns.namespace("EMD_binary_sensor")
 EMD = EMD_ns.class_("EMD", binary_sensor.BinarySensor, cg.Component)
 
-CONFIG_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(EMD),
-        cv.Required(CONTROLLER_ID): cv.use_id(PHCController),
-        cv.Required(ADDRESS): cv.int_range(min=0, max=31),
-        cv.Required(CHANNEL): cv.int_range(min=0, max=15),
-    }
-).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = (
+    binary_sensor.binary_sensor_schema(EMD)
+    .extend(
+        {
+            cv.GenerateID(): cv.declare_id(EMD),
+            cv.Required(CONTROLLER_ID): cv.use_id(PHCController),
+            cv.Required(ADDRESS): cv.int_range(min=0, max=31),
+            cv.Required(CHANNEL): cv.int_range(min=0, max=15),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 def to_code(config):

--- a/components/EMD/light.py
+++ b/components/EMD/light.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import light, switch
+from esphome.components import light
+from esphome.components.light import LightType
 from esphome.const import CONF_OUTPUT_ID
 
 from ..PHCController import CONTROLLER_ID, PHCController
@@ -15,14 +16,18 @@ EMDLight = amd_light_ns.class_(
     "EMD_light", light.LightOutput, cg.EntityBase, cg.Component
 )
 
-CONFIG_SCHEMA = light.BINARY_LIGHT_SCHEMA.extend(
-    {
-        cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(EMDLight),
-        cv.Required(CONTROLLER_ID): cv.use_id(PHCController),
-        cv.Required(ADDRESS): cv.int_range(min=0, max=31),
-        cv.Required(CHANNEL): cv.int_range(min=0, max=15),
-    }
-).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = (
+    light.light_schema(EMDLight, type_=LightType.BINARY)
+    .extend(
+        {
+            cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(EMDLight),
+            cv.Required(CONTROLLER_ID): cv.use_id(PHCController),
+            cv.Required(ADDRESS): cv.int_range(min=0, max=31),
+            cv.Required(CHANNEL): cv.int_range(min=0, max=15),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 def to_code(config):

--- a/components/JRM/cover.py
+++ b/components/JRM/cover.py
@@ -5,6 +5,8 @@ from esphome.const import CONF_ID
 
 from ..PHCController import CONTROLLER_ID, PHCController
 
+DEPENDENCIES = ["PHCController"]
+
 JRM_cover_ns = cg.esphome_ns.namespace("JRM_cover")
 JRMCover = JRM_cover_ns.class_("JRM", cover.Cover, cg.Component)
 
@@ -29,7 +31,8 @@ def _validate(config):
 
 
 CONFIG_SCHEMA = cv.All(
-    cover.COVER_SCHEMA.extend(
+    cover.cover_schema(JRMCover)
+    .extend(
         {
             cv.GenerateID(): cv.declare_id(JRMCover),
             cv.Required(CONTROLLER_ID): cv.use_id(PHCController),
@@ -68,7 +71,8 @@ CONFIG_SCHEMA = cv.All(
                 }
             ),
         }
-    ).extend(cv.COMPONENT_SCHEMA),
+    )
+    .extend(cv.COMPONENT_SCHEMA),
     _validate,
 )
 

--- a/components/PHCController/PHCController.cpp
+++ b/components/PHCController/PHCController.cpp
@@ -5,6 +5,8 @@
 #include "esphome/components/uart/uart_component_esp32_arduino.h"
 #elif USE_ESP8266
 #include "esphome/components/uart/uart_component_esp8266.h"
+#elif USE_ESP_IDF
+#include "esphome/components/uart/uart_component_esp_idf.h"
 #endif
 
 namespace esphome
@@ -24,12 +26,15 @@ namespace esphome
             setRxFIFOFull(1) is used to force immediate parsing of incoming data which fixes the delay issue
             */
 #ifdef USE_ESP32_FRAMEWORK_ARDUINO
+#pragma message("Arduino Framework only supported until ESPHome 2025.9!")
             uart::ESP32ArduinoUARTComponent *uartComponent = static_cast<uart::ESP32ArduinoUARTComponent *>(this->parent_);
             uartComponent->get_hw_serial()->setRxTimeout(1);
             uartComponent->get_hw_serial()->setRxFIFOFull(1);
-#else
-#pragma message("Response timings on the IDF Framework are likely incorrect. Please use the Arduino Framework and ideally an ESP32.")
-            ESP_LOGW(TAG, "Response timings on the IDF Framework are likely incorrect. Please use the Arduino Framework and ideally an ESP32.");
+#elif USE_ESP_IDF
+            uart::IDFUARTComponent *uartComponent = static_cast<uart::IDFUARTComponent *>(this->parent_);
+            uart_port_t hw_serial_number = static_cast<uart_port_t>(uartComponent->get_hw_serial_number());
+            uart_set_rx_timeout(hw_serial_number, 1);
+            uart_set_rx_full_threshold(hw_serial_number, 1);
 #endif
 
             if (flow_control_pin_ != NULL)

--- a/components/PHCController/__init__.py
+++ b/components/PHCController/__init__.py
@@ -17,12 +17,16 @@ FLOW_CONTROL_PIN = "flow_control_pin"
 phc_controller_ns = cg.esphome_ns.namespace("phc_controller")
 PHCController = phc_controller_ns.class_("PHCController", cg.Component, uart.UARTDevice)
 
-CONFIG_SCHEMA = uart.UART_DEVICE_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(PHCController),
-        cv.Required(UART_ID): cv.use_id(UARTComponent),
-        cv.Optional(FLOW_CONTROL_PIN): pins.gpio_output_pin_schema,
-    }
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(PHCController),
+            cv.Required(UART_ID): cv.use_id(UARTComponent),
+            cv.Optional(FLOW_CONTROL_PIN): pins.gpio_output_pin_schema,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA)
 )
 
 

--- a/tests/base.yaml
+++ b/tests/base.yaml
@@ -3,6 +3,8 @@ esphome:
 
 esp32:
   board: esp32dev
+  framework:
+    type: esp-idf
 
 external_components:
   - source:

--- a/tests/full.yaml
+++ b/tests/full.yaml
@@ -3,6 +3,8 @@ esphome:
 
 esp32:
   board: esp32dev
+  framework:
+    type: esp-idf
 
 external_components:
   - source:


### PR DESCRIPTION
* fix: bump python version for black in CI

* fix: replace deprecated schema-notation

* refactor: align schema definition/dependency loading with esphome

* fix: fix timing issue when using IDF framework; migrate to IDF